### PR TITLE
More explicit error when requests module is missing

### DIFF
--- a/setup-hooks.py
+++ b/setup-hooks.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 import argparse
 import os
-import requests
 import sys
+
+try:
+    import requests
+except ImportError:
+    print("The 'requests' module is required to run this script. Please install it and retry.")
+    exit(1)
 
 # The event types that Datadog's Source Code Integration requires
 EVENT_TYPES = [


### PR DESCRIPTION
We need the `requests` module to be installed. This is made explicit in the README of this repository, but is easily overlooked by users that download and run the script from the in-app instructions.

This updates the script to provide a smoother error message when the module is missing.