### PR TITLE
Accept uk1 Datadog site

### DIFF
--- a/setup-hooks.ps1
+++ b/setup-hooks.ps1
@@ -1,7 +1,7 @@
 #!/usr/bin/env pwsh
 param(
     [Parameter(Mandatory=$true)]
-    [ValidateSet("datadoghq.com", "datadoghq.eu", "ap1.datadoghq.com", "us3.datadoghq.com", "us5.datadoghq.com", "ap2.datadoghq.com", "ddog-gov.com", "datad0g.com")]
+    [ValidateSet("datadoghq.com", "datadoghq.eu", "ap1.datadoghq.com", "us3.datadoghq.com", "us5.datadoghq.com", "ap2.datadoghq.com", "ddog-gov.com", "uk1.datadoghq.com", "datad0g.com")]
     [string]$DdSite,
 
     [Parameter(Mandatory=$true)]

--- a/setup-hooks.py
+++ b/setup-hooks.py
@@ -41,6 +41,7 @@ VALID_DD_SITES = [
     "us3.datadoghq.com",
     "us5.datadoghq.com",
     "ap2.datadoghq.com",
+    "uk1.datadoghq.com",
     "datad0g.com",
 ]
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"2a4336df-fed3-449a-989c-1b3bad2fb301","workflowId":"8cce8495-e641-48ae-81d0-cd5aa859b4d4","codeChangeId":"8cce8495-e641-48ae-81d0-cd5aa859b4d4","sourceType":"assistant"} -->
## Summary
Enable the setup hook scripts to accept uk1.datadoghq.com as a valid Datadog site so Azure DevOps hook setup can target the UK1 region from either Python or PowerShell.

## Changes
- Added uk1.datadoghq.com to setup-hooks.py VALID_DD_SITES before the staging site entry.
- Added uk1.datadoghq.com to setup-hooks.ps1 ValidateSet before the staging site entry.
- Preserved datad0g.com as the final staging site in both lists.

## Testing
- Ran python3 -m py_compile setup-hooks.py.
- Ran Python validation to confirm setup-hooks.ps1 includes uk1.datadoghq.com before datad0g.com and keeps datad0g.com last.
- Ran git diff --check.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/2a4336df-fed3-449a-989c-1b3bad2fb301)

Comment @datadog to request changes