### PR TITLE
add ms.vss-code.git-pullrequest-comment-event to service hooks setup

### DIFF
--- a/setup-hooks.py
+++ b/setup-hooks.py
@@ -13,6 +13,7 @@ EVENT_TYPES = [
     "git.pullrequest.updated",
     "git.pullrequest.merged",
     "git.push",
+    "ms.vss-code.git-pullrequest-comment-event",
     "ms.vss-pipelines.run-state-changed-event",
     "ms.vss-pipelines.stage-state-changed-event",
     "ms.vss-pipelines.job-state-changed-event",


### PR DESCRIPTION
Event required to support Azure Devops in Bits Code Sessions.